### PR TITLE
Fix mosquitto_pub example

### DIFF
--- a/losant_setup.sh
+++ b/losant_setup.sh
@@ -38,4 +38,4 @@ echo ""
 echo "Subscribe to commands with:
     mosquitto_sub -t losant/$deviceId/command"
 echo "Update state with:
-    mosquitto_pub -t losant/$deviceId/state -m {\"data\": {\"varName\": \"OK\"}}"
+    mosquitto_pub -t losant/$deviceId/state -m '{\"data\": {\"varName\": \"OK\"}}'"


### PR DESCRIPTION
The example command needs quotes around the JSON data. If not, you'll get an error.   

<img width="694" alt="image 2017-08-21 at 11 09 38 am" src="https://user-images.githubusercontent.com/1156260/29525719-979bface-8661-11e7-8c93-09c04aab4a33.png">
